### PR TITLE
Ffent 3871 json bug review

### DIFF
--- a/static/lightroomapi.json
+++ b/static/lightroomapi.json
@@ -819,17 +819,7 @@
         ],
         "properties": {
           "inputs": {
-            "type": "object",
-            "minProperties": 1,
-            "description": "The input assets for your call.",
-            "required": [
-              "source"
-            ],
-            "properties": {
-              "source": {
-                "$ref": "#/components/schemas/InputsSchema"
-              }
-            }
+            "$ref": "#/components/schemas/InputsSchema"
           },
           "outputs": {
             "$ref": "#/components/schemas/OutputsSchema"
@@ -846,17 +836,7 @@
         ],
         "properties": {
           "inputs": {
-            "type": "object",
-            "minProperties": 1,
-            "description": "The input assets for your call.",
-            "required": [
-              "source"
-            ],
-            "properties": {
-              "source": {
-                "$ref": "#/components/schemas/InputsSchema"
-              }
-            }
+            "$ref": "#/components/schemas/InputsSchema"
           },
           "outputs": {
             "$ref": "#/components/schemas/OutputsSchema"
@@ -1201,7 +1181,23 @@
       },
       "InputsSchema": {
         "type": "object",
-        "description": "Input asset definition."
+        "description": "Input asset definition.",
+        "properties": {
+          "href": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL or pre-signed URL of the input asset."
+          },
+          "storage": {
+            "type": "string",
+            "description": "Storage type for the input asset."
+          }
+        },
+        "required": ["href", "storage"],
+        "example": {
+          "href": "https://SAMPLE-ff-test.s3.amazonaws.com/TEST-asdk/firefly-uploads/EXAMPLE",
+          "storage": "external"
+        }
       },
       "OutputsSchema": {
         "type": "array",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Found errors and changes:
 1. PostImageEditSchema
• The property edits is not required in the backend, whereas the API spec defines it as required.

 2. PostAutoStraightenSchema.outputs
• In the backend, outputs must be an array, but the API spec defines it as an object.
• outputs is described only as a generic object without defined properties; it needs href and storage.

 3. PostAutoStraightenSchema.inputs
• The API spec currently defines inputs["source"] and marks source as required, which is incorrect.
• The backend expects inputs without a source property. Instead, it must include two fields: href and storage.

## Related Issue

https://jira.corp.adobe.com/browse/FFENT-3871

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
