### PR TITLE
FFENT-8319: Add Support button with Airtable link to top nav

### DIFF
--- a/src/pages/config.md
+++ b/src/pages/config.md
@@ -17,7 +17,7 @@
     - [API Reference](/api/index.md)
 
 - buttons:
-    - [Submit Feedback](https://developer.adobe.com/firefly-services/docs/guides/support/)
+    - [Support](https://airtable.com/appu5RTWgdM95jynx/pagyuT1qspNJcPU2E/form)
     - [Console](https://developer.adobe.com/console/) consoleId
 
 - subPages:


### PR DESCRIPTION
## FFENT-8319: Add Support button to FFE pages

**Jira:** https://jira.corp.adobe.com/browse/FFENT-8319

- Renames top nav button from "Submit feedback" to "Support"
- Points button to Airtable feedback form: https://airtable.com/appu5RTWgdM95jynx/pagyuT1qspNJcPU2E/form

**Config change:** `buttons` in src/pages/config.md (EDS)

Made with [Cursor](https://cursor.com)