### PR TITLE
docs/FFENT-7940- Add Illustrator API to Firefly Services top nav

### DIFF
--- a/src/pages/config.md
+++ b/src/pages/config.md
@@ -10,6 +10,7 @@
         - [Audio/Video API](https://developer.adobe.com/audio-video-firefly-services/?aio_internal) - Docs and references for Audio/Video API.
         - [InDesign API](https://developer.adobe.com/firefly-services/docs/indesign-apis/?aio_internal) - Docs and references for InDesign API.
         - [Substance 3D API](https://developer.adobe.com/firefly-services/docs/s3dapi/?aio_internal) - Unlock generative AI for rendering and object composites.
+        - [Illustrator API](https://developer.adobe.com/firefly-services/docs/illustrator/?aio_internal) - Docs and references for Illustrator API.
         - [Content Tagging API](https://experienceleague.adobe.com/docs/experience-platform/intelligent-services/content-commerce-ai/overview.html) - Docs and references for Content Tagging services.
     - [About Lightroom API](/index.md)
     - [Getting Started](/getting-started/index.md)


### PR DESCRIPTION
# Summary
Adds the Illustrator API link to the All Firefly Services top navigation in the EDS site config so it matches the live Illustrator docs.

# Changes

## `src/pages/config.md`
* Adds Illustrator API entry after Substance 3D API and before Content Tagging (before Workflow Builder API where that product appears in the list).

# Context

## Jira
[FFENT-7940](https://jira.corp.adobe.com/browse/FFENT-7940)

Made with [Cursor](https://cursor.com)