### PR TITLE
docs: Lightroom API deprecation notice for July 31 EoL (FFENT-13605)

### DIFF
--- a/src/pages/config.md
+++ b/src/pages/config.md
@@ -24,6 +24,8 @@
     - [Console](https://developer.adobe.com/console/) consoleId
 
 - subPages:
+    - What's New header
+    - [Lightroom API Deprecation](/getting-started/deprecation-announcement/index.md)
     - Getting Started header
     - [Authentication](/getting-started/index.md)
     - [Technical Usage Notes](/getting-started/usage/index.md)

--- a/src/pages/getting-started/deprecation-announcement/index.md
+++ b/src/pages/getting-started/deprecation-announcement/index.md
@@ -1,0 +1,45 @@
+---
+title: Deprecation Announcements in Lightroom API
+description: Learn about the deprecations happening in the Lightroom API.
+hideBreadcrumbNav: true
+keywords:
+  - deprecation
+  - lightroom api
+  - lightroom deprecation
+  - end of life
+---
+# Lightroom API deprecation announcement
+
+The Lightroom API will reach **end-of-life (EoL) on July 31, 2026**.
+
+Customers currently using the Lightroom API are encouraged to begin planning their migration to Photoshop API v2. For guidance about this change, refer to the FAQs below.
+
+<AccordionItem slots="heading, text" />
+
+### What should I do?
+
+Migrate to Photoshop API v2 before **August of 2026** to avoid service disruptions. See the [Photoshop API v2 migration guide](https://developer.adobe.com/firefly-services/docs/photoshop/guides/photoshop-v2/v1-to-v2/) for details.
+
+<AccordionItem slots="heading, text" />
+
+### Why is Adobe making this change?
+
+The Lightroom API is being phased out as Adobe consolidates its imaging API capabilities into the modern Photoshop API v2 platform.
+
+<AccordionItem slots="heading, text" />
+
+### When is this happening?
+
+End of Life (EOL): July 31, 2026.
+
+<AccordionItem slots="heading, text" />
+
+### Where can I find resources?
+
+Migration guides are available on the [Photoshop API v2 migration guide page](https://developer.adobe.com/firefly-services/docs/photoshop/guides/photoshop-v2/v1-to-v2/).
+
+<AccordionItem slots="heading, text"/>
+
+### Who can help me with migration?
+
+Your Adobe Customer Success Manager and Support Team are available to answer questions and guide you through the transition.

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -39,6 +39,14 @@ twitter:
 
 Unlock the potential of Lightroom through an easy-to-use RESTful API.
 
+<Announcement slots="heading, text, button" variant="primary" backgroundColor="background-color-gray"/>
+
+#### Lightroom API End-of-Life Notice
+
+The Lightroom API will reach end-of-life on **July 31, 2026**.
+
+- [View Deprecation Announcement](/getting-started/deprecation-announcement/index.md)
+
 ## Overview
 
 Welcome to the Adobe Lightroom API, now integrated into Firefly Services. Our API follows REST-like principles, utilizing standard HTTP response codes, verbs, and authentication methods that return JSON-encoded responses. While the examples provided are in cURL, feel free to develop your application in any preferred language.

--- a/static/lightroomapi.json
+++ b/static/lightroomapi.json
@@ -86,7 +86,7 @@
                         "$ref": "#/components/responses/JobErrorAssetLinkInvalid"
                     }
                 },
-                "deprecated": false
+                "deprecated": true
             }
         },
         "/lrService/autoTone": {
@@ -148,7 +148,7 @@
                         "$ref": "#/components/responses/JobErrorAssetLinkInvalid"
                     }
                 },
-                "deprecated": false
+                "deprecated": true
             }
         },
         "/lrService/edit": {
@@ -216,7 +216,7 @@
                         "$ref": "#/components/responses/JobErrorAssetLinkInvalid"
                     }
                 },
-                "deprecated": false
+                "deprecated": true
             }
         },
         "/lrService/presets": {
@@ -286,7 +286,7 @@
                         "$ref": "#/components/responses/JobErrorAssetLinkInvalid"
                     }
                 },
-                "deprecated": false
+                "deprecated": true
             }
         },
         "/lrService/xmp": {
@@ -353,7 +353,7 @@
                         "$ref": "#/components/responses/JobErrorAssetLinkInvalid"
                     }
                 },
-                "deprecated": false
+                "deprecated": true
             }
         },
         "/lrService/status/{jobId}": {
@@ -414,7 +414,7 @@
                         }
                     }
                 },
-                "deprecated": false
+                "deprecated": true
             }
         }
     },


### PR DESCRIPTION
## Summary

- Adds deprecation announcement page (`getting-started/deprecation-announcement/index.md`) modeled after the Photoshop API deprecation notice, with AccordionItem FAQs and a link to the PS v2 migration guide
- Adds a **What's New** section to the sidebar nav (`config.md`) pointing to the new announcement page
- Adds an `<Announcement>` banner to the landing page (`index.md`) surfacing the July 31, 2026 EoL date
- Marks all 6 Lightroom API endpoints as `deprecated: true` in the OpenAPI spec (`lightroomapi.json`)

## Test plan

- [ ] Verify the **What's New** section appears in the sidebar with the deprecation link
- [ ] Verify the `<Announcement>` banner renders on the Lightroom API landing page
- [ ] Verify the deprecation announcement page renders with all FAQ accordions
- [ ] Verify the API reference renders deprecated labels on all 6 endpoints

Jira: [FFENT-13605](https://jira.corp.adobe.com/browse/FFENT-13605)

🤖 Generated with [Claude Code](https://claude.com/claude-code)